### PR TITLE
Inject cwl outputs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "workflomics-benchmarker"
-version = "0.2.0"
+version = "0.2.1"
 description = "Library used to execute workflows (in CWL) and benchmark them as part of the Workflomics ecosystem."
 authors = ["Vedran Kasalica <v.kaslica@esciencecenter.nl>",
             "Nauman Ahmed <n.ahmed@esciencecenter.nl>",

--- a/src/workflomics_benchmarker/benchmark_utils.py
+++ b/src/workflomics_benchmarker/benchmark_utils.py
@@ -161,7 +161,7 @@ def benchmark_successful_step_execution(successfully_executed_steps: List[str], 
             if entry["step"] == step:
                 entry["status"] = "✓"
                 entry["time"] = max(1, execution_time_step)
-                entry["memory"] = max(1, max_memory_step)
+                entry["memory"] = max(1, max_memory_step) if max_memory_step != "-" else "-"
                 entry["warnings"] = warnings_step
                 entry["errors"] = errors_step
                 entry["identified_proteins"] = count_identified_proteins


### PR DESCRIPTION
The benchmarker can now inject outputs before executing workflows, to collect data needed for the scientific benchmarking.